### PR TITLE
New plugin to recalculate electron conversion veto from miniaod

### DIFF
--- a/plugins/ICElectronConversionFromMiniAODCalculator.cc
+++ b/plugins/ICElectronConversionFromMiniAODCalculator.cc
@@ -1,0 +1,60 @@
+#include "ICAnalysis/ElectronConversionCalculator/plugins/ICElectronConversionFromMiniAODCalculator.h"
+#include <vector>
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
+#include "DataFormats/PatCandidates/interface/Electron.h"
+#include "DataFormats/EgammaCandidates/interface/Conversion.h"
+#include "RecoEgamma/EgammaTools/interface/ConversionTools.h"
+
+ICElectronConversionFromMiniAODCalculator::ICElectronConversionFromMiniAODCalculator(
+    const edm::ParameterSet& config)
+    : input_(config.getParameter<edm::InputTag>("input")),
+      input_beamspot_(config.getParameter<edm::InputTag>("beamspot")),
+      input_conversions_(config.getParameter<edm::InputTag>("conversions")) {
+  produces<edm::ValueMap<bool> >();
+}
+
+ICElectronConversionFromMiniAODCalculator::~ICElectronConversionFromMiniAODCalculator() {}
+
+void ICElectronConversionFromMiniAODCalculator::produce(edm::Event& event,
+                                 const edm::EventSetup& setup) {
+  std::auto_ptr<edm::ValueMap<bool> > product(new edm::ValueMap<bool>());
+  edm::Handle<pat::ElectronCollection> elecs_handle;
+  event.getByLabel(input_, elecs_handle);
+
+  edm::Handle<reco::BeamSpot> beamspot_handle;
+  event.getByLabel(input_beamspot_, beamspot_handle);
+
+  edm::Handle<reco::ConversionCollection> conversions_handle;
+  event.getByLabel(input_conversions_, conversions_handle);
+
+  std::vector<bool> values(elecs_handle->size(), 0.);
+  for (unsigned i = 0; i < elecs_handle->size(); ++i) {
+    reco::GsfElectron const& src = elecs_handle->at(i);
+    values[i] = ConversionTools::hasMatchedConversion(
+        src, conversions_handle, beamspot_handle->position(),
+        true, 2.0, 1e-6, 0);
+  }
+
+  edm::ValueMap<bool>::Filler filler(*product);
+  filler.insert(elecs_handle, values.begin(), values.end());
+  filler.fill();
+
+  event.put(product);
+}
+
+void ICElectronConversionFromMiniAODCalculator::beginJob() {}
+
+void ICElectronConversionFromMiniAODCalculator::endJob() {}
+
+// define this as a plug-in
+DEFINE_FWK_MODULE(ICElectronConversionFromMiniAODCalculator);

--- a/plugins/ICElectronConversionFromMiniAODCalculator.h
+++ b/plugins/ICElectronConversionFromMiniAODCalculator.h
@@ -1,0 +1,29 @@
+#ifndef UserCode_ICHiggsTauTau_ICElectronConversionFromMiniAODCalculator_h
+#define UserCode_ICHiggsTauTau_ICElectronConversionFromMiniAODCalculator_h
+
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+/**
+ * @brief Produces an edm::ValueMap<bool> for the electron conversion-rejection
+ *flag
+ */
+class ICElectronConversionFromMiniAODCalculator : public edm::EDProducer {
+ public:
+  explicit ICElectronConversionFromMiniAODCalculator(const edm::ParameterSet &);
+  ~ICElectronConversionFromMiniAODCalculator();
+
+ private:
+  virtual void beginJob();
+  virtual void produce(edm::Event &, const edm::EventSetup &);
+  virtual void endJob();
+
+  edm::InputTag input_;
+  edm::InputTag input_beamspot_;
+  edm::InputTag input_conversions_;
+};
+
+#endif

--- a/python/default_producer_cfi.py
+++ b/python/default_producer_cfi.py
@@ -6,6 +6,13 @@ icElectronConversionCalculator = cms.EDProducer('ICElectronConversionCalculator'
     conversions = cms.InputTag("allConversions")
 )
 
+icElectronConversionFromMiniAODCalculator = cms.EDProducer('ICElectronConversionFromMiniAODCalculator',
+    input       = cms.InputTag("slimmedElectrons"),
+    beamspot    = cms.InputTag("offlineBeamSpot"),
+    conversions = cms.InputTag("reducedEgamma:reducedConversions")
+)
+
+
 icElectronConversionFromPatCalculator = cms.EDProducer('ICElectronConversionFromPatCalculator',
     input       = cms.InputTag("patElectrons")
 )


### PR DESCRIPTION
This new plugin is basically the same as ICElectronConversionCalculator, the only difference being that this one takes a pat::ElectronCollection instead of a reco::GsfElectronCollection as input. (I'm open to suggestions of nicer ways to do this than just duplicating the code and changing one line...)